### PR TITLE
(#15) Add support for Cake v2.0.0

### DIFF
--- a/Source/Cake.Eazfuscator.Net.Tests/Cake.Eazfuscator.Net.Tests.csproj
+++ b/Source/Cake.Eazfuscator.Net.Tests/Cake.Eazfuscator.Net.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="1.0.0" />
-    <PackageReference Include="Cake.Testing" Version="1.0.0" />
+    <PackageReference Include="Cake.Core" Version="2.0.0" />
+    <PackageReference Include="Cake.Testing" Version="2.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">

--- a/Source/Cake.Eazfuscator.Net/Cake.Eazfuscator.Net.csproj
+++ b/Source/Cake.Eazfuscator.Net/Cake.Eazfuscator.Net.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DebugType>pdbonly</DebugType>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
@@ -37,22 +36,23 @@
   </ItemGroup>
 
   <!--
-    CCG0007 suppressions — Cake.Core 1.0.0 also targets net461 and net5.0,
-    but both are EOL and not reliably installable from `actions/setup-dotnet`
-    in our `[ windows-2025, ubuntu-24.04 ]` matrix. netstandard2.0 covers
-    every Cake-1-era host we care about (cake.tool 1.x and 2.x both load
-    netstandard2.0 addin DLLs natively). CCG0009 ("recommended Cake 6.0.0")
-    stays as a warning — we're deliberately on Cake.Core 1.0.0 for this
+    CCG0007 suppressions — Cake.Core 2.0.0 dropped netstandard2.0 (the
+    Cake-1 TFM); its required-target list is now netcoreapp3.1 + net5.0
+    + net6.0. netcoreapp3.1 and net5.0 are both EOL and not reliably
+    installable from `actions/setup-dotnet` in our `[ windows-2025,
+    ubuntu-24.04 ]` matrix; net6.0 covers every Cake-2-era host
+    (cake.tool 2.x runs on net6.0). CCG0009 ("recommended Cake 6.0.0")
+    stays as a warning — we're deliberately on Cake.Core 2.0.0 for this
     release; it resolves naturally at the eventual 6.0.0 catch-up.
   -->
   <ItemGroup>
-    <CakeContribGuidelinesOmitTargetFramework Include="net461" />
+    <CakeContribGuidelinesOmitTargetFramework Include="netcoreapp3.1" />
     <CakeContribGuidelinesOmitTargetFramework Include="net5.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Cake.Eazfuscator.Net">
-      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Eazfuscator.Net\netstandard2.0\Cake.Eazfuscator.Net.dll</HintPath>
+      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Eazfuscator.Net\net6.0\Cake.Eazfuscator.Net.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="1.3.0" />
+    <PackageReference Include="Cake.Frosting" Version="2.3.0" />
   </ItemGroup>
 </Project>

--- a/demo/script/eazfuscator.cake
+++ b/demo/script/eazfuscator.cake
@@ -1,4 +1,4 @@
-#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.Eazfuscator.Net/netstandard2.0/Cake.Eazfuscator.Net.dll"
+#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.Eazfuscator.Net/net6.0/Cake.Eazfuscator.Net.dll"
 
 using Cake.Eazfuscator.Net;
 


### PR DESCRIPTION
Closes #15.

Second per-Cake-major release after `1.0.0`. Single Cake.Core 2.0.0 reference, no mixed conditionals — same release cadence as Cake.Prompt's per-major arc.

## Single commit

**(#15) Cake v2.0.0 catch-up: bump Cake.Core/Common/Testing to 2.0.0**

* Addin csproj — `Cake.Core` / `Cake.Common` `1.0.0` → `2.0.0`. **First per-major TFM rotation**: TFM moves from `netstandard2.0` to `net6.0` only (Cake.Core 2.0.0 dropped netstandard2.0, so the Cake-1 choice no longer applies). CCG0007 omit list updated: `net461` dropped (no longer in Cake.Core 2.0.0's required-target list); `netcoreapp3.1` added. `<DebugType>pdbonly</DebugType>` dropped — canonical workspace shape is no `<DebugType>` (defaults to `portable`, what snupkg expects).
* Tests csproj — `Cake.Testing` `1.0.0` → `2.0.0`; `Cake.Core` `1.0.0` → `2.0.0`. Tests TFM stays at `net6.0`.
* `demo/script/eazfuscator.cake` — `#reference` path `netstandard2.0` → `net6.0`. `cake.tool` stays pinned at `2.3.0` (already Cake-2-era from the Cake-1 compromise).
* `demo/frosting/build/Build.csproj` — `Cake.Frosting` `1.3.0` → **`2.3.0`** (latest-of-major per workspace standard, not `2.0.0` which is the addin/tests contract anchor). HintPath path `netstandard2.0` → `net6.0`.

## Local verification

* `dotnet cake recipe.cake --target=Package` — **31/31 tests passing** on net6.0; nupkg + snupkg both produced cleanly.
* `./demo/script/build.ps1` + `./demo/frosting/build.ps1` — both demos green.

## Out of scope

* Further Cake-major bumps (separate issues per major).
* `ArgumentNullException.ThrowIfNull` modernisation — workspace convention defers this to the Cake-4 boundary.