### PR TITLE
(#17) Add support for Cake v3.0.0

### DIFF
--- a/Source/Cake.Eazfuscator.Net.Tests/Cake.Eazfuscator.Net.Tests.csproj
+++ b/Source/Cake.Eazfuscator.Net.Tests/Cake.Eazfuscator.Net.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="2.0.0" />
-    <PackageReference Include="Cake.Testing" Version="2.0.0" />
+    <PackageReference Include="Cake.Core" Version="3.0.0" />
+    <PackageReference Include="Cake.Testing" Version="3.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">

--- a/Source/Cake.Eazfuscator.Net/Cake.Eazfuscator.Net.csproj
+++ b/Source/Cake.Eazfuscator.Net/Cake.Eazfuscator.Net.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -35,24 +35,9 @@
     <InternalsVisibleTo Include="Cake.Eazfuscator.Net.Tests" />
   </ItemGroup>
 
-  <!--
-    CCG0007 suppressions — Cake.Core 2.0.0 dropped netstandard2.0 (the
-    Cake-1 TFM); its required-target list is now netcoreapp3.1 + net5.0
-    + net6.0. netcoreapp3.1 and net5.0 are both EOL and not reliably
-    installable from `actions/setup-dotnet` in our `[ windows-2025,
-    ubuntu-24.04 ]` matrix; net6.0 covers every Cake-2-era host
-    (cake.tool 2.x runs on net6.0). CCG0009 ("recommended Cake 6.0.0")
-    stays as a warning — we're deliberately on Cake.Core 2.0.0 for this
-    release; it resolves naturally at the eventual 6.0.0 catch-up.
-  -->
   <ItemGroup>
-    <CakeContribGuidelinesOmitTargetFramework Include="netcoreapp3.1" />
-    <CakeContribGuidelinesOmitTargetFramework Include="net5.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="2.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="3.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -9,6 +9,6 @@
     <Reference Include="Cake.Eazfuscator.Net">
       <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Eazfuscator.Net\net6.0\Cake.Eazfuscator.Net.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="2.3.0" />
+    <PackageReference Include="Cake.Frosting" Version="3.2.0" />
   </ItemGroup>
 </Project>

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
         "cake.tool": {
-            "version": "2.3.0",
+            "version": "3.2.0",
             "commands": [
                 "dotnet-cake"
             ]


### PR DESCRIPTION
Closes #17.

Third per-Cake-major release after `2.0.0`. Single Cake.Core 3.0.0 reference, no mixed conditionals.

## Single commit

**(#17) Cake v3.0.0 catch-up: bump Cake.Core/Common/Testing to 3.0.0**

* Addin csproj — `Cake.Core` / `Cake.Common` `2.0.0` → `3.0.0`. **First multi-target rotation**: TFM moves from `net6.0` to `net6.0;net7.0`. CCG0007 omit ItemGroup removed entirely (Cake.Core 3.0.0's required-target list is now covered by the addin's `net6.0;net7.0`).
* Tests csproj — `Cake.Testing` `2.0.0` → `3.0.0`; `Cake.Core` `2.0.0` → `3.0.0`. TFM stays at `net6.0` (lowest of the addin's multi-target list).
* `demo/script/.config/dotnet-tools.json` — `cake.tool` `2.3.0` → **`3.2.0`** (latest-of-major, verified live against NuGet flat-container).
* `demo/frosting/build/Build.csproj` — `Cake.Frosting` `2.3.0` → **`3.2.0`** (latest-of-major; NOT `3.0.0` which is the addin/tests contract anchor). HintPath stays at `.../net6.0/...` since net6.0 remains the lowest TFM in the multi-target list.

## Local verification

* `dotnet cake recipe.cake --target=Package` — **31/31 tests passing** on net6.0; nupkg + snupkg both produced cleanly.
* `./demo/script/build.ps1` + `./demo/frosting/build.ps1` — both demos green.

## Out of scope

* Further Cake-major bumps (separate issues per major).
* `ArgumentNullException.ThrowIfNull` modernisation — workspace convention defers this to the Cake-4 boundary.