### PR TITLE
(#19) Add support for Cake v4.0.0

### DIFF
--- a/Source/Cake.Eazfuscator.Net.Tests/Cake.Eazfuscator.Net.Tests.csproj
+++ b/Source/Cake.Eazfuscator.Net.Tests/Cake.Eazfuscator.Net.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="3.0.0" />
-    <PackageReference Include="Cake.Testing" Version="3.0.0" />
+    <PackageReference Include="Cake.Core" Version="4.0.0" />
+    <PackageReference Include="Cake.Testing" Version="4.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">

--- a/Source/Cake.Eazfuscator.Net/Cake.Eazfuscator.Net.csproj
+++ b/Source/Cake.Eazfuscator.Net/Cake.Eazfuscator.Net.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -36,8 +36,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="3.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="3.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Cake.Eazfuscator.Net/EazfuscatorNetRunner.cs
+++ b/Source/Cake.Eazfuscator.Net/EazfuscatorNetRunner.cs
@@ -20,15 +20,8 @@ namespace Cake.Eazfuscator.Net
 
         internal void Run(IEnumerable<FilePath> inputFiles, EazfuscatorNetSettings settings)
         {
-            if (inputFiles == null)
-            {
-                throw new ArgumentNullException(nameof(inputFiles));
-            }
-
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
+            ArgumentNullException.ThrowIfNull(inputFiles);
+            ArgumentNullException.ThrowIfNull(settings);
 
             Run(settings, GetArguments(inputFiles, settings));
         }

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -9,6 +9,6 @@
     <Reference Include="Cake.Eazfuscator.Net">
       <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Eazfuscator.Net\net6.0\Cake.Eazfuscator.Net.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="3.2.0" />
+    <PackageReference Include="Cake.Frosting" Version="4.2.0" />
   </ItemGroup>
 </Project>

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
         "cake.tool": {
-            "version": "3.2.0",
+            "version": "4.2.0",
             "commands": [
                 "dotnet-cake"
             ]


### PR DESCRIPTION
Closes #19.

Fourth per-Cake-major release after `3.0.0`. Single Cake.Core 4.0.0 reference, no mixed conditionals.

## Single commit

**(#19) Cake v4.0.0 catch-up: bump Cake.Core/Common/Testing to 4.0.0**

* Addin csproj — `Cake.Core` / `Cake.Common` `3.0.0` → `4.0.0`. TFMs extend from `net6.0;net7.0` to `net6.0;net7.0;net8.0`.
* Tests csproj — `Cake.Testing` `3.0.0` → `4.0.0`; `Cake.Core` `3.0.0` → `4.0.0`. Tests TFM stays at `net6.0` (lowest of the addin's multi-target list).
* `demo/script/.config/dotnet-tools.json` — `cake.tool` `3.2.0` → **`4.2.0`** (latest-of-major).
* `demo/frosting/build/Build.csproj` — `Cake.Frosting` `3.2.0` → **`4.2.0`** (latest-of-major). HintPath stays at `.../net6.0/...`.
* **Source modernisation**: `EazfuscatorNetRunner.Run` — convert the two long-form `if (x == null) throw new ArgumentNullException(nameof(x))` blocks to `ArgumentNullException.ThrowIfNull(...)`. The Cake-4 boundary is the workspace convention for this (all addin TFMs are now `net6+` and the helper is available).

## Local verification

* `dotnet cake recipe.cake --target=Package` — **31/31 tests passing** on net6.0; nupkg + snupkg both produced cleanly.
* `./demo/script/build.ps1` + `./demo/frosting/build.ps1` — both demos green.

## Out of scope

* Further Cake-major bumps (separate issues per major).