### PR TITLE
(#21) Add support for Cake v5.0.0

### DIFF
--- a/Source/Cake.Eazfuscator.Net.Tests/Cake.Eazfuscator.Net.Tests.csproj
+++ b/Source/Cake.Eazfuscator.Net.Tests/Cake.Eazfuscator.Net.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
     <NoWarn>$(NoWarn);SA1600;SA1633;CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="4.0.0" />
-    <PackageReference Include="Cake.Testing" Version="4.0.0" />
+    <PackageReference Include="Cake.Core" Version="5.0.0" />
+    <PackageReference Include="Cake.Testing" Version="5.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">

--- a/Source/Cake.Eazfuscator.Net/Cake.Eazfuscator.Net.csproj
+++ b/Source/Cake.Eazfuscator.Net/Cake.Eazfuscator.Net.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -36,8 +36,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="4.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)\</RunWorkingDirectory>
     <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Cake.Eazfuscator.Net">
-      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Eazfuscator.Net\net6.0\Cake.Eazfuscator.Net.dll</HintPath>
+      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Eazfuscator.Net\net8.0\Cake.Eazfuscator.Net.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="4.2.0" />
+    <PackageReference Include="Cake.Frosting" Version="5.1.0" />
   </ItemGroup>
 </Project>

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
         "cake.tool": {
-            "version": "4.2.0",
+            "version": "5.1.0",
             "commands": [
                 "dotnet-cake"
             ]

--- a/demo/script/eazfuscator.cake
+++ b/demo/script/eazfuscator.cake
@@ -1,4 +1,4 @@
-#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.Eazfuscator.Net/net6.0/Cake.Eazfuscator.Net.dll"
+#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.Eazfuscator.Net/net8.0/Cake.Eazfuscator.Net.dll"
 
 using Cake.Eazfuscator.Net;
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "8.0.100",
+      "version": "9.0.100",
       "rollForward": "latestFeature"
     }
   }


### PR DESCRIPTION
Closes #21.

Fifth per-Cake-major release after `4.0.0`. Single Cake.Core 5.0.0 reference, no mixed conditionals.

## Single commit

**(#21) Cake v5.0.0 catch-up: bump Cake.Core/Common/Testing to 5.0.0**

Six file changes — biggest catch-up in the arc:

* Addin csproj — `Cake.Core` / `Cake.Common` `4.0.0` → `5.0.0`. **TFM trim + add**: `net6.0;net7.0;net8.0` → `net8.0;net9.0`. net6.0 + net7.0 dropped (both EOL); net9.0 added.
* Tests csproj — `Cake.Testing` `4.0.0` → `5.0.0`; `Cake.Core` `4.0.0` → `5.0.0`. **Tests TFM rotation**: `net6.0` → `net8.0` (lowest of the addin's new multi-target list).
* `global.json` — SDK `8.0.100` → `9.0.100` to match the addin's new highest TFM `net9.0`.
* `demo/script/.config/dotnet-tools.json` — `cake.tool` `4.2.0` → **`5.1.0`** (latest-of-major).
* `demo/script/eazfuscator.cake` — `#reference` path `net6.0` → `net8.0`.
* `demo/frosting/build/Build.csproj` — `Cake.Frosting` `4.2.0` → **`5.1.0`** (latest-of-major). `<TargetFramework>` `net6.0` → `net8.0` (Cake.Frosting 5.x drops netstandard2.0). HintPath `net6.0` → `net8.0`.

## Local verification

* `dotnet cake recipe.cake --target=Package` — **31/31 tests passing** on net8.0; nupkg + snupkg both produced cleanly.
* `./demo/script/build.ps1` + `./demo/frosting/build.ps1` — both demos green.

## Out of scope

* Cake-6 catch-up — separate issue, will add `demo/sdk` and `net10.0`.