### PR TITLE
(#23) Add support for Cake v6.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,12 +74,13 @@ jobs:
           cake-version: tool-manifest
 
       # The demo/ folders exercise the just-built addin DLL under
-      # Cake-major-matching cake.tool / Cake.Frosting versions. They
-      # run in their OWN tool/package context (independent of
-      # recipe.cake's cake.tool, which is constrained by Cake.Recipe's
-      # runtime). Both demos consume the addin from
-      # BuildArtifacts/temp/_PublishedLibraries/ populated by
-      # DotNetCore-Pack. demo/sdk joins at the Cake 6 catch-up.
+      # Cake-major-matching cake.tool / Cake.Frosting / Cake.Sdk
+      # versions. They run in their OWN tool/package context
+      # (independent of recipe.cake's cake.tool, which is constrained
+      # by Cake.Recipe's runtime). demo/script and demo/frosting
+      # consume the addin from BuildArtifacts/temp/_PublishedLibraries/
+      # populated by DotNetCore-Pack; demo/sdk builds the addin from
+      # source via the #:project directive in cake.cs.
 
       - name: Run demo/script
         if: success()
@@ -90,6 +91,12 @@ jobs:
         if: success()
         shell: pwsh
         run: ./demo/frosting/build.ps1
+
+      - name: Run demo/sdk
+        if: success()
+        shell: pwsh
+        working-directory: ./demo/sdk
+        run: dotnet cake.cs
 
       - name: Upload Issues-Report
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5

--- a/Source/Cake.Eazfuscator.Net.Tests/Cake.Eazfuscator.Net.Tests.csproj
+++ b/Source/Cake.Eazfuscator.Net.Tests/Cake.Eazfuscator.Net.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="5.0.0" />
-    <PackageReference Include="Cake.Testing" Version="5.0.0" />
+    <PackageReference Include="Cake.Core" Version="6.0.0" />
+    <PackageReference Include="Cake.Testing" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">

--- a/Source/Cake.Eazfuscator.Net/Cake.Eazfuscator.Net.csproj
+++ b/Source/Cake.Eazfuscator.Net/Cake.Eazfuscator.Net.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -36,8 +36,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="6.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="6.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Cake.Eazfuscator.Net/EazfuscatorNetAliases.cs
+++ b/Source/Cake.Eazfuscator.Net/EazfuscatorNetAliases.cs
@@ -48,7 +48,7 @@ namespace Cake.Eazfuscator.Net
         /// Executes <see href="https://www.gapotchenko.com/eazfuscator.net">Eazfuscator.Net.exe</see> on single file using the specified settings.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="inputFile">The file to be obfuscated</param>
+        /// <param name="inputFile">The file to be obfuscated.</param>
         /// <param name="settings">The settings.</param>
         [CakeMethodAlias]
         public static void EazfuscatorNet(this ICakeContext context, FilePath inputFile, EazfuscatorNetSettings settings)
@@ -60,7 +60,7 @@ namespace Cake.Eazfuscator.Net
         /// Executes <see href="https://www.gapotchenko.com/eazfuscator.net">Eazfuscator.Net.exe</see> on selection of files using the specified settings.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="inputFiles">The files to be obfuscated</param>
+        /// <param name="inputFiles">The files to be obfuscated.</param>
         /// <param name="settings">The settings.</param>
         [CakeMethodAlias]
         public static void EazfuscatorNet(this ICakeContext context, IEnumerable<FilePath> inputFiles, EazfuscatorNetSettings settings)

--- a/Source/Cake.Eazfuscator.Net/EazfuscatorNetRunner.cs
+++ b/Source/Cake.Eazfuscator.Net/EazfuscatorNetRunner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -8,16 +8,31 @@ using Cake.Core.Tooling;
 
 namespace Cake.Eazfuscator.Net
 {
+    /// <summary>
+    /// The Eazfuscator.NET runner.
+    /// </summary>
     internal sealed class EazfuscatorNetRunner : Tool<EazfuscatorNetSettings>
     {
-        private readonly ICakeEnvironment _environment;
+        private readonly ICakeEnvironment environment;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EazfuscatorNetRunner"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
         internal EazfuscatorNetRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools)
             : base(fileSystem, environment, processRunner, tools)
         {
-            _environment = environment;
+            this.environment = environment;
         }
 
+        /// <summary>
+        /// Invokes Eazfuscator.Net.exe on the specified input files using the supplied settings.
+        /// </summary>
+        /// <param name="inputFiles">The files to be obfuscated.</param>
+        /// <param name="settings">The settings.</param>
         internal void Run(IEnumerable<FilePath> inputFiles, EazfuscatorNetSettings settings)
         {
             ArgumentNullException.ThrowIfNull(inputFiles);
@@ -26,8 +41,16 @@ namespace Cake.Eazfuscator.Net
             Run(settings, GetArguments(inputFiles, settings));
         }
 
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
         protected override string GetToolName() => "Eazfuscator.Net";
 
+        /// <summary>
+        /// Gets the name of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
         protected override IEnumerable<string> GetToolExecutableNames()
         {
             yield return "Eazfuscator.Net.exe";
@@ -39,7 +62,7 @@ namespace Cake.Eazfuscator.Net
 
             foreach (var inputFile in inputFiles)
             {
-                builder.AppendQuoted(inputFile.MakeAbsolute(_environment).FullPath);
+                builder.AppendQuoted(inputFile.MakeAbsolute(environment).FullPath);
             }
 
             if (settings.NoLogo)
@@ -50,13 +73,13 @@ namespace Cake.Eazfuscator.Net
             if (settings.OutputFile != null)
             {
                 builder.Append("--output");
-                builder.AppendQuoted(settings.OutputFile.MakeAbsolute(_environment).FullPath);
+                builder.AppendQuoted(settings.OutputFile.MakeAbsolute(environment).FullPath);
             }
 
             if (settings.KeyFile != null)
             {
                 builder.Append("--key-file");
-                builder.AppendQuoted(settings.KeyFile.MakeAbsolute(_environment).FullPath);
+                builder.AppendQuoted(settings.KeyFile.MakeAbsolute(environment).FullPath);
             }
 
             if (!string.IsNullOrWhiteSpace(settings.KeyContainer))
@@ -90,7 +113,7 @@ namespace Cake.Eazfuscator.Net
             if (settings.MSBuildProjectPath != null)
             {
                 builder.Append("--msbuild-project-path");
-                builder.AppendQuoted(settings.MSBuildProjectPath.MakeAbsolute(_environment).FullPath);
+                builder.AppendQuoted(settings.MSBuildProjectPath.MakeAbsolute(environment).FullPath);
             }
 
             if (!string.IsNullOrWhiteSpace(settings.MSBuildProjectConfiguration))
@@ -108,7 +131,7 @@ namespace Cake.Eazfuscator.Net
             if (settings.MSBuildSolutionPath != null)
             {
                 builder.Append("--msbuild-solution-path");
-                builder.AppendQuoted(settings.MSBuildSolutionPath.MakeAbsolute(_environment).FullPath);
+                builder.AppendQuoted(settings.MSBuildSolutionPath.MakeAbsolute(environment).FullPath);
             }
 
             if (settings.ProtectProject)
@@ -139,7 +162,7 @@ namespace Cake.Eazfuscator.Net
 
                 foreach (var probingPath in settings.ProbingPaths)
                 {
-                    fullPathsStringArray.Add(probingPath.MakeAbsolute(_environment).FullPath);
+                    fullPathsStringArray.Add(probingPath.MakeAbsolute(environment).FullPath);
                 }
 
                 var probingPathsString = string.Join(";", fullPathsStringArray);
@@ -155,7 +178,7 @@ namespace Cake.Eazfuscator.Net
             if (settings.ConfigurationFile != null)
             {
                 builder.Append("--configuration-file");
-                builder.AppendQuoted(settings.ConfigurationFile.MakeAbsolute(_environment).FullPath);
+                builder.AppendQuoted(settings.ConfigurationFile.MakeAbsolute(environment).FullPath);
             }
 
             if (settings.Statistics)

--- a/Source/Cake.Eazfuscator.Net/EazfuscatorNetSettings.cs
+++ b/Source/Cake.Eazfuscator.Net/EazfuscatorNetSettings.cs
@@ -5,18 +5,12 @@ using Cake.Core.Tooling;
 namespace Cake.Eazfuscator.Net
 {
     /// <summary>
-    /// Contains settings used by <see cref="EazfuscatorNetRunner"/>. See <see
-    /// href="https://help.gapotchenko.com/eazfuscator.net/45/deployment/command-line-interface">Comman Line Interface</see>
-    /// or run
-    /// <code>
-    /// .\Eazfuscator.Net.exe --help
-    /// </code>
-    /// for more details.
+    /// Contains settings used by <see cref="EazfuscatorNetRunner"/>. See the <see href="https://help.gapotchenko.com/eazfuscator.net/45/deployment/command-line-interface">command-line interface documentation</see> or run <c>.\Eazfuscator.Net.exe --help</c> for more details.
     /// </summary>
     public sealed class EazfuscatorNetSettings : ToolSettings
     {
         /// <summary>
-        /// Gets or sets a property specifing whether or not to suppress logo message.
+        /// Gets or sets a value indicating whether to suppress the logo message.
         /// </summary>
         public bool NoLogo { get; set; }
 
@@ -85,7 +79,7 @@ namespace Cake.Eazfuscator.Net
         public string? ErrorSandbox { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifing whether to check the input file and ensure it is obfuscated.
+        /// Gets or sets a value indicating whether to check the input file and ensure it is obfuscated.
         /// </summary>
         public bool EnsureObfuscated { get; set; }
 
@@ -137,12 +131,12 @@ namespace Cake.Eazfuscator.Net
         public string? CompatibilityVersion { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifing whether to check installed version.
+        /// Gets or sets a value indicating whether to check the installed version.
         /// </summary>
         /// <remarks>
         /// <para>
         /// Instructs to check the installed version of Eazfuscator.NET and return the result as exit code. This
-        /// option cannot be combined with other options. (To get more help, please try to use it)
+        /// option cannot be combined with other options. (To get more help, please try to use it.)
         /// </para>
         /// </remarks>
         public bool CheckVersion { get; set; }

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -9,6 +9,6 @@
     <Reference Include="Cake.Eazfuscator.Net">
       <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Eazfuscator.Net\net8.0\Cake.Eazfuscator.Net.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="5.1.0" />
+    <PackageReference Include="Cake.Frosting" Version="6.1.0" />
   </ItemGroup>
 </Project>

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
         "cake.tool": {
-            "version": "5.1.0",
+            "version": "6.1.0",
             "commands": [
                 "dotnet-cake"
             ]

--- a/demo/sdk/cake.cs
+++ b/demo/sdk/cake.cs
@@ -1,0 +1,110 @@
+#!/usr/bin/env dotnet
+#:sdk Cake.Sdk@6.1.1
+#:project ../../Source/Cake.Eazfuscator.Net/Cake.Eazfuscator.Net.csproj
+#:property Nullable=enable
+
+// Nullable=enable propagates `<Nullable>enable</Nullable>` to the
+// SDK's synthetic csproj so the addin's `FilePath?` annotations on
+// EazfuscatorNetSettings load in the right context (silences
+// CS8632).
+//
+// NoWarn=CS8603 silences "Possible null reference return" warnings
+// emitted from Cake.Sdk's generated `CakeMethodAliases.g.cs` — the
+// source generator doesn't currently propagate the addin's `?`
+// annotations into the synthesized wrappers, so it reports the
+// nullable returns as suspicious. Not actionable from our code;
+// upstream issue against Cake.Sdk.
+#:property NoWarn=CS8603
+
+// Cake SDK consumer demo for Cake.Eazfuscator.Net. Runs as a
+// file-based .NET program (introduced in .NET 10) using the
+// Cake.Sdk directives. The #:project directive above lets the SDK
+// build the addin from source rather than referencing a published
+// nupkg.
+//
+// To run locally:
+//   cd demo/sdk
+//   dotnet cake.cs
+//
+// Runs the same two checks the script and frosting demos run.
+
+using Cake.Eazfuscator.Net;
+
+Task("Default")
+    .IsDependentOn("Settings-Roundtrip")
+    .IsDependentOn("Alias-ResolvesToToolError");
+
+Task("Settings-Roundtrip")
+    .Does(() =>
+{
+    var settings = new EazfuscatorNetSettings
+    {
+        NoLogo = true,
+        OutputFile = File("./out/obfuscated.dll"),
+        KeyFile = File("./key.snk"),
+        KeyContainer = "fake-container",
+        Quiet = true,
+        EnsureObfuscated = true,
+        MSBuildProjectPath = File("./demo.csproj"),
+        MSBuildProjectConfiguration = "Release",
+        MSBuildProjectPlatform = "AnyCPU",
+        MSBuildSolutionPath = File("./demo.sln"),
+        ProtectProject = false,
+        UnprotectProject = false,
+        CompatibilityVersion = "5.0",
+        CheckVersion = false,
+        ProbingPaths = new Cake.Core.IO.DirectoryPath[] { Directory("./bin/Release") },
+        WarningsAsErrors = "all",
+        ConfigurationFile = File("./eazfuscator.config"),
+        Statistics = true,
+        NewlineFlush = true,
+    };
+
+    AssertThat(settings.NoLogo, "NoLogo roundtrip");
+    AssertThat(settings.OutputFile != null && settings.OutputFile.FullPath.EndsWith("obfuscated.dll"), "OutputFile roundtrip");
+    AssertThat(settings.KeyFile != null, "KeyFile roundtrip");
+    AssertThat(settings.KeyContainer == "fake-container", "KeyContainer roundtrip");
+    AssertThat(settings.EnsureObfuscated, "EnsureObfuscated roundtrip");
+    AssertThat(settings.CompatibilityVersion == "5.0", "CompatibilityVersion roundtrip");
+    AssertThat(settings.ProbingPaths != null, "ProbingPaths roundtrip");
+
+    Information("EazfuscatorNetSettings OK (representative properties round-tripped)");
+
+    var empty = new EazfuscatorNetSettings();
+    AssertThat(!empty.NoLogo, "Default NoLogo is false");
+    AssertThat(empty.OutputFile == null, "Default OutputFile is null");
+    AssertThat(empty.KeyContainer == null, "Default KeyContainer is null");
+
+    Information("EazfuscatorNetSettings default constructor OK");
+});
+
+Task("Alias-ResolvesToToolError")
+    .Does(() =>
+{
+    var threw = false;
+    try
+    {
+        EazfuscatorNet(File("./fake-input.dll"));
+    }
+    catch (Exception ex) when (ex.Message.IndexOf("Eazfuscator", StringComparison.OrdinalIgnoreCase) >= 0
+                              || ex.Message.IndexOf("not be found", StringComparison.OrdinalIgnoreCase) >= 0
+                              || ex.Message.IndexOf("could not locate", StringComparison.OrdinalIgnoreCase) >= 0)
+    {
+        threw = true;
+        Information("Alias resolved correctly; tool-not-found exception was: {0}", ex.Message);
+    }
+
+    AssertThat(threw, "Expected EazfuscatorNet alias to throw a tool-not-found exception (Eazfuscator.Net.exe is licensed and not installed in CI)");
+});
+
+RunTarget("Default");
+
+// ----- Helpers (must come AFTER top-level statements per CS8803) -----
+
+static void AssertThat(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new Exception("Assertion failed: " + message);
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "9.0.100",
+      "version": "10.0.100",
       "rollForward": "latestFeature"
     }
   }


### PR DESCRIPTION
Closes #23.

Sixth and final per-Cake-major release. Closes the catch-up arc.

## Two commits

### Commit 1 — `(#23) First-party StyleCop warning cleanup`

Clears the 13 SA-warnings carried since the v0.x baseline:

* **SA1309** (1): rename `_environment` field in `EazfuscatorNetRunner.cs` to `environment`. Constructor uses `this.environment = environment` to disambiguate.
* **SA1600** (5): add `<summary>` doc comments to `EazfuscatorNetRunner` class, ctor, `Run`, `GetToolName`, `GetToolExecutableNames`.
* **SA1623** (3): rewrite three boolean property summaries in `EazfuscatorNetSettings.cs` (`NoLogo`, `EnsureObfuscated`, `CheckVersion`) to start with "Gets or sets a value indicating whether".
* **SA1629** (4): add missing periods (class summary, `CheckVersion` remarks, two `<param>` elements in `EazfuscatorNetAliases.cs`). Class summary also got the "Comman Line Interface" typo fixed to "command-line interface" in the same area.

### Commit 2 — `(#23) Cake v6.0.0 catch-up`

* `Cake.Core` / `Cake.Common` `5.0.0` → `6.0.0`; `Cake.Testing` `5.0.0` → `6.0.0`.
* Addin TFMs `net8.0;net9.0` → `net8.0;net9.0;net10.0`. Tests TFM stays at `net8.0`.
* `global.json` SDK `9.0.100` → `10.0.100`.
* `demo/script/.config/dotnet-tools.json`: `cake.tool` `5.1.0` → `6.1.0` (latest-of-major).
* `demo/frosting/build/Build.csproj`: `Cake.Frosting` `5.1.0` → `6.1.0` (latest-of-major). HintPath stays at `net8.0`.
* **`demo/sdk/cake.cs` (NEW)**: Cake.Sdk consumer demo using `Cake.Sdk@6.1.1` with `#:sdk` and `#:project` directives. First per-major release where Cake.Sdk can join the demo family.
* `.github/workflows/build.yml`: new "Run demo/sdk" step running `dotnet cake.cs`.
* **CCG0009 cleared** — the deliberate "recommended Cake 6.0.0" warning carried through the entire arc resolves.

## Local verification

* `dotnet cake recipe.cake --target=Package` — **31/31 tests passing** on net8.0; nupkg + snupkg produced cleanly. **Zero first-party warnings** (only Cake.Recipe-internal CS0618 obsolete-API warnings remain, which clear when Cake.Recipe ships a newer version).
* `./demo/script/build.ps1` + `./demo/frosting/build.ps1` + `./demo/sdk` (`dotnet cake.cs`) — all three demos green.

## Arc complete

This closes the per-Cake-major catch-up arc for Cake.Eazfuscator.Net. After v6.0.0 ships, the AddinDiscoverer should pick up the addin against Cake 6 in `cake-version.yml`.